### PR TITLE
Make optional attributes nullable

### DIFF
--- a/lacerda.gemspec
+++ b/lacerda.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "coveralls",           ["~> 0.8"]
   spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'pry-rescue'
   spec.add_development_dependency 'pry-stack_explorer'
 end

--- a/lacerda.gemspec
+++ b/lacerda.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "coveralls",           ["~> 0.8"]
   spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'pry-rescue'
-  spec.add_development_dependency 'pry-stack_explorer'
+  # spec.add_development_dependency 'pry-byebug'
+  # spec.add_development_dependency 'pry-rescue'
+  # spec.add_development_dependency 'pry-stack_explorer'
 end

--- a/lacerda.gemspec
+++ b/lacerda.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "rake",          ["~> 10.2"]
   spec.add_runtime_dependency "json-schema",   ["~> 2.5"]
-  spec.add_runtime_dependency "redsnow",       ["~> 0.4"]
+  spec.add_runtime_dependency "redsnow",       ["~> 0.4.3"]
   spec.add_runtime_dependency "colorize"
   spec.add_runtime_dependency "blumquist",     ["~> 0.3"]
 

--- a/lacerda.gemspec
+++ b/lacerda.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "rake",          ["~> 10.2"]
-  spec.add_runtime_dependency "json-schema",   ["~> 2.5"]
+  spec.add_runtime_dependency "json-schema",   ["~> 2.5.1"]
   spec.add_runtime_dependency "redsnow",       ["~> 0.4.3"]
   spec.add_runtime_dependency "colorize"
   spec.add_runtime_dependency "blumquist",     ["~> 0.3"]

--- a/lib/lacerda/compare/json_schema.rb
+++ b/lib/lacerda/compare/json_schema.rb
@@ -50,7 +50,7 @@ module Lacerda
         # Let's go:
 
         # 1)
-        if (consume['type'] and publish['type'])
+        if consume['type'] and publish['type']
           consume_types = ([consume['type']].flatten - ["null"]).sort
           publish_types = [publish['type']].flatten.sort
           if consume_types != publish_types
@@ -58,7 +58,7 @@ module Lacerda
           end
 
         # 2)
-        elsif(consume['$ref'] and publish['$ref'])
+        elsif consume['$ref'] and publish['$ref']
          resolved_consume = resolve_pointer(consume['$ref'], @contained_schema)
          resolved_publish = resolve_pointer(publish['$ref'], @containing_schema)
 
@@ -67,7 +67,7 @@ module Lacerda
          return schema_contains?(publish: resolved_publish, consume: resolved_consume, location: location)
 
         # 3)
-        elsif(consume['type'] and publish['$ref'])
+        elsif consume['type'] and publish['$ref']
           if resolved_ref = resolve_pointer(publish['$ref'], @containing_schema)
             return schema_contains?(publish: resolved_ref, consume: consume, location: location)
           else
@@ -75,7 +75,7 @@ module Lacerda
           end
 
         # 4)
-        elsif(consume['$ref'] and publish['type'])
+        elsif consume['$ref'] and publish['type']
           return _e(:ERR_NOT_SUPPORTED, location, nil)
         end
 
@@ -185,8 +185,6 @@ module Lacerda
           containing_property = @containing_schema['properties'][property]
           if !containing_property
             _e(:ERR_MISSING_DEFINITION, [@initial_location, property], "(in publish.mson)")
-          elsif !contained_property
-            _e(:ERR_MISSING_DEFINITION, [@initial_location, property], "(in consume.mson)")
           else
             resolved_containing_property = data_for_pointer(
               containing_property,

--- a/lib/lacerda/compare/json_schema.rb
+++ b/lib/lacerda/compare/json_schema.rb
@@ -145,7 +145,7 @@ module Lacerda
               compatible_consume_type_found = true
             end
             @errors = original_errors
-            return _e(:ERR_MISSING_SINGLE_PUBLISH_MULTI_CONSUME, location, publish_type) unless compatible_consume_type_found
+            return _e(:ERR_MISSING_SINGLE_PUBLISH_MULTI_CONSUME, location, publish['type']) unless compatible_consume_type_found
 
           # Mixed case 2/2:
           elsif consume['properties'] and publish['oneOf']

--- a/lib/lacerda/compare/json_schema.rb
+++ b/lib/lacerda/compare/json_schema.rb
@@ -32,16 +32,16 @@ module Lacerda
           resolved_contained_property = data_for_pointer(property, @contained_schema)
           containing_property = @containing_schema['properties'][property]
           if !containing_property
-            _e(:ERR_MISSING_DEFINITION, [@initial_location, property]) 
+            _e(:ERR_MISSING_DEFINITION, [@initial_location, property], nil, false)
           else
             resolved_containing_property = data_for_pointer(
               containing_property,
               @containing_schema
             )
             schema_contains?(
-              resolved_containing_property,
-              resolved_contained_property,
-              [property]
+              publish: resolved_containing_property,
+              consume: resolved_contained_property,
+              location: [property]
             )
           end
         end
@@ -54,7 +54,10 @@ module Lacerda
         false
       end
 
-      def schema_contains?(publish, consume, location = [])
+      def schema_contains?(options)
+        publish      = options[:publish]
+        consume      = options[:consume]
+        location     = options[:location] || []
 
         # We can only compare types and $refs, so let's make
         # sure they're there
@@ -77,8 +80,10 @@ module Lacerda
 
         # 1)
         if (consume['type'] and publish['type'])
-          if consume['type'] != publish['type']
-            return _e(:ERR_TYPE_MISMATCH, location, "#{consume['type']} != #{publish['type']}")
+          consume_types = ([consume['type']].flatten - ["null"]).sort
+          publish_types = [publish['type']].flatten.sort
+          if consume_types != publish_types
+            return _e(:ERR_TYPE_MISMATCH, location, "Consume types #{consume_types.to_json} not compatible with publish types #{publish_types.to_json}")
           end
 
         # 2)
@@ -88,19 +93,19 @@ module Lacerda
 
          return _e(:ERR_MISSING_POINTER, location, consume['$ref']) unless resolved_consume
          return _e(:ERR_MISSING_POINTER, location, publish['$ref']) unless resolved_publish
-         return schema_contains?(resolved_publish, resolved_consume, location)
+         return schema_contains?(publish: resolved_publish, consume: resolved_consume, location: location)
 
         # 3)
         elsif(consume['type'] and publish['$ref'])
           if resolved_ref = resolve_pointer(publish['$ref'], @containing_schema)
-            return schema_contains?(resolved_ref, consume, location)
+            return schema_contains?(publish: resolved_ref, consume: consume, location: location)
           else
             return _e(:ERR_MISSING_POINTER, location, publish['$ref'])
           end
 
         # 4)
         elsif(consume['$ref'] and publish['type'])
-          return _e(:ERR_NOT_SUPPORTED, location)
+          return _e(:ERR_NOT_SUPPORTED, location, nil)
         end
 
         # Make sure required properties in consume are required in publish
@@ -111,18 +116,80 @@ module Lacerda
 
         # We already know that publish and consume's type are equal
         # but if they're objects, we need to do some recursion
-        if consume['type'] == 'object'
-          consume['properties'].each do |property, schema|
-            return _e(:ERR_MISSING_PROPERTY, location, property) unless publish['properties'][property]
-            return false unless schema_contains?(publish['properties'][property], schema, location + [property])
+        if [consume['type']].flatten.include?('object')
+
+          # An object can either be described by its properties
+          # like this:
+          #
+          # (1) { "type": "object", "properties": { "active": { "type": "boolean" } }
+          #
+          # or by allowing a bunch of other types like this:
+          #
+          # (2) { "type": "object", "oneOf": [ {"$ref": "#/definitions/foo"}, {"type": "null"} ]
+          #
+          # So we need to take care of both cases for both "sides"
+          # (publish and consume), so 4 cases in total.
+          #
+          # First, the easy case:
+          if consume['properties'] and publish['properties']
+            consume['properties'].each do |property, schema|
+              return _e(:ERR_MISSING_PROPERTY, location, property) unless publish['properties'][property]
+              return false unless schema_contains?(publish: publish['properties'][property], consume: schema, location: location + [property])
+            end
+
+          # Now on to the trickier case, both have 'oneOf's:
+          #
+          # For each possible object type from the publish schema we have
+          # to check if we find a compatible type in the consume schema.
+          #
+          # It's not sufficient to just compare the names of the objects,
+          # because they might be different in the publish and consume
+          # schemas.
+          elsif publish['oneOf'] and consume['oneOf']
+            publish_types = publish['oneOf']
+            consume_types = [consume['oneOf']].flatten.compact
+
+            # Check all publish types for a compatible consume type
+            publish_types.each do |publish_type|
+              compatible_consume_type_found = false
+              consume_types.each do |consume_type|
+                next unless schema_contains?(publish: publish_type, consume: consume_type, location: location + [publish_type])
+                compatible_consume_type_found = true
+              end
+              return _e(:ERR_MISSING_MULTI_PUBLISH_MULTI_CONSUME, location, publish_type) unless compatible_consume_type_found
+            end
+
+          # Mixed case 1/2:
+          elsif consume['oneOf'] and publish['properties']
+            consume_types = ([consume['oneOf']].flatten - [{"type" => "null"}]).sort
+            compatible_consume_type_found = false
+            consume_types.each do |consume_type|
+              next unless schema_contains?(publish: publish, consume: consume_type, location: location)
+              compatible_consume_type_found = true
+            end
+            return _e(:ERR_MISSING_SINGLE_PUBLISH_MULTI_CONSUME, location, publish_type) unless compatible_consume_type_found
+
+          # Mixed case 2/2:
+          elsif consume['properties'] and publish['oneOf']
+            publish_types = ([publish['oneOf']].flatten - [{"type" => "null"}]).sort
+            incompatible_publish_type= nil
+            publish_types.each do |publish_type|
+              next if schema_contains?(publish: publish_type, consume: consume, location: location)
+              incompatible_publish_type = publish_type
+            end
+            return _e(:ERR_MISSING_MULTI_PUBLISH_SINGLE_CONSUME, location, incompatible_publish_type) if incompatible_publish_type
+
+          # We don't know how to handle this 😳
+          else
+            return _e(:ERR_NOT_SUPPORTED, location, "Consume schema didn't have properties defined and publish schema no oneOf")
           end
         end
 
         if consume['type'] == 'array'
           sorted_publish = publish['items'].sort
           consume['items'].sort.each_with_index do |item, i|
-            next if schema_contains?(sorted_publish[i], item)
-            return _e(:ERR_ARRAY_ITEM_MISMATCH, location)
+            next if schema_contains?(publish: sorted_publish[i], consume: item)
+            return _e(:ERR_ARRAY_ITEM_MISMATCH, location, nil)
           end
         end
 

--- a/lib/lacerda/compare/json_schema.rb
+++ b/lib/lacerda/compare/json_schema.rb
@@ -161,6 +161,7 @@ module Lacerda
             return _e(:ERR_MISSING_MULTI_PUBLISH_SINGLE_CONSUME, location, incompatible_publish_type) if incompatible_publish_type
 
           # We don't know how to handle this 😳
+          # an object can either have "properties" or "oneOf", if the schema has anything else, we break
           else
             return _e(:ERR_NOT_SUPPORTED, location, "Consume schema didn't have properties defined and publish schema no oneOf")
           end

--- a/lib/lacerda/conversion/data_structure.rb
+++ b/lib/lacerda/conversion/data_structure.rb
@@ -96,7 +96,7 @@ module Lacerda
           @schema['properties'][name] = spec
 
           # Mark the property as required
-          @schema['required'] << name if attributes.include?('required')
+          @schema['required'] << name if is_required
         end
       end
 

--- a/lib/lacerda/conversion/data_structure.rb
+++ b/lib/lacerda/conversion/data_structure.rb
@@ -57,16 +57,23 @@ module Lacerda
         return unless @data['sections']
         return unless @data['sections'].length > 0
         members = @data['sections'].select{|d| d['class'] == 'memberType' }.first['content'].select{|d| d['class'] == 'property' }
+
+        # Iterate over each property
         members.each do |s|
+
+          # Pluck some things out of the AST
           content = s['content']
           type_definition = content['valueDefinition']['typeDefinition']
           type = type_definition['typeSpecification']['name']
+          attributes = type_definition['attributes'] || []
+          is_required = attributes.include?('required')
 
+          # Prepare the json schema fragment
           spec = {}
           name = Lacerda.underscore(content['name']['literal'])
 
           # This is either type: primimtive or $ref: reference_name
-          spec.merge!(primitive_or_reference(type))
+          spec.merge!(primitive_or_reference(type, is_required))
 
           # We might have a description
           spec['description'] = content['description']
@@ -74,7 +81,7 @@ module Lacerda
           # If it's an array, we need to pluck out the item types
           if type == 'array'
             nestedTypes = type_definition['typeSpecification']['nestedTypes']
-            spec['items'] = nestedTypes.map{|t| primitive_or_reference(t) }
+            spec['items'] = nestedTypes.map{|t| primitive_or_reference(t, is_required) }
 
           # If it's an object, we need recursion
           elsif type == 'object'
@@ -85,20 +92,28 @@ module Lacerda
             end
           end
 
+          # Add the specification of this property to the schema
           @schema['properties'][name] = spec
-          if attributes = type_definition['attributes']
-            @schema['required'] << name if attributes.include?('required')
-          end
+
+          # Mark the property as required
+          @schema['required'] << name if attributes.include?('required')
         end
       end
 
-      def primitive_or_reference(type)
-	return { 'type' => 'object' } if type.blank?
+      def primitive_or_reference(type, is_required)
+      	return { 'type' => 'object' } if type.blank?
 
         if PRIMITIVES.include?(type)
-          { 'type' => type }
+          types = [type]
+          types << 'null' unless is_required
+          { 'type' => types }
         else
-          { '$ref' => "#/definitions/#{self.class.scope(@scope, type['literal'])}" }
+          types = [{'$ref' => "#/definitions/#{self.class.scope(@scope, type['literal'])}" }]
+          types << { 'type' => 'null' } unless is_required
+          {
+            'type' => 'object',
+            'oneOf' => types
+          }
         end
       end
 

--- a/spec/lib/lacerda/compare/json_schema_spec.rb
+++ b/spec/lib/lacerda/compare/json_schema_spec.rb
@@ -123,6 +123,138 @@ describe JsonSchema do
           schema_b['definitions']['post']['properties']['primary_tag'] = tag_as_pointer
           expect(comparator.contains?(schema_b)).to be_falsy
         end
+
+        describe "with oneOfs" do
+          it 'consume marks a property nullable that is not nullable in the publish' do
+            publish = <<-JSON
+              {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "title": "publisher",
+                "definitions": {
+                  "testObject": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": [
+                          "number"
+                        ],
+                        "description": ""
+                      }
+                    },
+                    "required": [ "id" ]
+                  }
+                },
+                "type": "object",
+                "properties": {
+                  "testObject": {
+                    "$ref": "#/definitions/testObject"
+                  }
+                }
+              }
+            JSON
+
+            consume = <<-JSON
+              {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "title": "publisher",
+                "definitions": {
+                  "testObject": {
+                    "type": "object",
+                    "oneOf": [
+                      { "type": "null" },
+                      {
+                        "type": "object",
+                        "required": [ "id" ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "number"
+                            ],
+                            "description": ""
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "type": "object",
+                "properties": {
+                  "testObject": {
+                    "$ref": "#/definitions/testObject"
+                  }
+                }
+              }
+            JSON
+
+            comparator = JsonSchema.new(JSON.parse(publish))
+            expect(comparator.contains?(JSON.parse(consume))).to be true
+          end
+
+          it 'consume marks a property nullable that is not nullable in the publish' do
+            consume = <<-JSON
+              {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "title": "publisher",
+                "definitions": {
+                  "testObject": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": [
+                          "number"
+                        ],
+                        "description": ""
+                      }
+                    },
+                    "required": [ "id" ]
+                  }
+                },
+                "type": "object",
+                "properties": {
+                  "testObject": {
+                    "$ref": "#/definitions/testObject"
+                  }
+                }
+              }
+            JSON
+
+            publish = <<-JSON
+              {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "title": "publisher",
+                "definitions": {
+                  "testObject": {
+                    "type": "object",
+                    "oneOf": [
+                      { "type": "null" },
+                      {
+                        "type": "object",
+                        "required": [ "id" ],
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "number"
+                            ],
+                            "description": ""
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "type": "object",
+                "properties": {
+                  "testObject": {
+                    "$ref": "#/definitions/testObject"
+                  }
+                }
+              }
+            JSON
+
+            comparator = JsonSchema.new(JSON.parse(publish))
+            expect(comparator.contains?(JSON.parse(consume))).to be false
+          end
+        end
       end
 
       context 'Json Schema a NOT containing other Json Schema b because of' do

--- a/spec/lib/lacerda/conversion_spec.rb
+++ b/spec/lib/lacerda/conversion_spec.rb
@@ -112,7 +112,7 @@ describe Lacerda::Conversion do
       end
 
       context "have properties with custom types that is" do
-        let(:valid_post){ {'id' => 1, 'title' => 'Servus', 'author_id' => 22} }
+        let(:valid_post){ {'id' => 1, 'title' => 'Servus', 'author_id' => 22, 'body' => 'We were somewhere around barstow on the edge of the desert' } }
         let(:invalid_tag){ {'id' => 1, 'variations' => [1]} }
 
         it "nonexistant" do

--- a/spec/lib/lacerda/conversion_spec.rb
+++ b/spec/lib/lacerda/conversion_spec.rb
@@ -71,7 +71,7 @@ describe Lacerda::Conversion do
     end
 
     it "parsed child objects in the consume schema" do
-      expect(consume_schema['definitions']['another_app::post']['properties']['primary_tag']['properties']['name']['type']).to eq "string"
+      expect(consume_schema['definitions']['another_app::post']['properties']['primary_tag']['properties']['name']['type']).to eq ["string", "null"]
     end
 
     it "found the tag description" do

--- a/spec/lib/lacerda/conversion_spec.rb
+++ b/spec/lib/lacerda/conversion_spec.rb
@@ -93,6 +93,16 @@ describe Lacerda::Conversion do
         expect('id' => '1').to_not match_schema(publish_schema, :tag)
       end
 
+      describe "have optional attributes are also nullable, until redsnow supports the nullable type" do
+        it "with the optional attribute not set at all" do
+          expect('id' => 1, 'author_id' => 2).to match_schema(publish_schema, :post)
+        end
+
+        it "with the optional attribute set to nil" do
+          expect('id' => 1, 'author_id' => 2, 'title' => nil).to match_schema(publish_schema, :post)
+        end
+      end
+
       it "have a wrong type array item" do
         expect('id' => 1, 'variations' => [1]).to_not match_schema(publish_schema, :tag)
       end

--- a/spec/lib/lacerda/published_object_spec.rb
+++ b/spec/lib/lacerda/published_object_spec.rb
@@ -16,6 +16,7 @@ describe Lacerda::PublishedObject do
     d = {
       id: 1,
       title: 'title',
+      body: 'text is nice',
       tag: {
         id: 1,
         name: 'name'

--- a/spec/lib/lacerda/service_spec.rb
+++ b/spec/lib/lacerda/service_spec.rb
@@ -40,6 +40,7 @@ describe Lacerda::Service do
 
   context "compatibilities" do
     it "publisher satisfies the consumer" do
+      binding.pry
       expect(publisher.satisfies?(consumer)).to be true
     end
   end

--- a/spec/lib/lacerda/service_spec.rb
+++ b/spec/lib/lacerda/service_spec.rb
@@ -115,7 +115,7 @@ describe Lacerda::Service do
         expect(consumer.consumes?('Publisher::Automobile')).to be false
       end
 
-      it "complains about an unknokwn type" do
+      it "complains about an unknown type" do
         expect(
           consumer.validate_object_to_consume('Publisher::unknown_type', {some: :data})
         ).to be false

--- a/spec/lib/lacerda/service_spec.rb
+++ b/spec/lib/lacerda/service_spec.rb
@@ -40,7 +40,6 @@ describe Lacerda::Service do
 
   context "compatibilities" do
     it "publisher satisfies the consumer" do
-      binding.pry
       expect(publisher.satisfies?(consumer)).to be true
     end
   end
@@ -83,7 +82,7 @@ describe Lacerda::Service do
       end
 
       it "accepts a valid object" do
-        valid_post = {id: 1, title: 'My title'}
+        valid_post = {id: 1, title: 'My title', body: 'Body'}
         expect(
           publisher.validate_object_to_publish('Post', valid_post)
         ).to be true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,18 +8,20 @@ CodeClimate::TestReporter.start
 
 require 'simplecov'
 require 'coveralls'
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-]
-SimpleCov.start{
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
+)
+SimpleCov.start {
   add_filter 'spec/'
 
   # Is this cheating? Have a 🍕 
   add_filter 'lib/lacerda/reporters/'
 }
 
-Dir[File.join(File.dirname(__FILE__), "/support/**/*.rb")].each{ |f| require f }
+Dir[File.join(File.dirname(__FILE__), "/support/**/*.rb")].each { |f| require f }
 
 require 'bundler'
 Bundler.require

--- a/spec/support/contracts/json_schema_test/app/publish.mson
+++ b/spec/support/contracts/json_schema_test/app/publish.mson
@@ -16,7 +16,7 @@ A post that only has a title, but no text body. Weird, right?
 
 ## Properties
 - id: 1 (number, required) - The unique identifier for a post
-- title: Work from home (string, required) - Title of the product
+- title: Work from home (string, nullable, optional) - Title of the product
 - author_id: 2 (number, required) - User id of author
 - primary_tag: (Tag, optional) - Property of custom type
 - tags: (array[Tag]) - An array with a custom type

--- a/spec/support/contracts/json_schema_test/app/publish.mson
+++ b/spec/support/contracts/json_schema_test/app/publish.mson
@@ -16,7 +16,7 @@ A post that only has a title, but no text body. Weird, right?
 
 ## Properties
 - id: 1 (number, required) - The unique identifier for a post
-- title: Work from home (string, nullable, optional) - Title of the product
+- title: Work from home (string) - Title of the product
 - author_id: 2 (number, required) - User id of author
 - primary_tag: (Tag, optional) - Property of custom type
 - tags: (array[Tag]) - An array with a custom type

--- a/spec/support/contracts/service_test/consumer/consume.mson
+++ b/spec/support/contracts/service_test/consumer/consume.mson
@@ -7,6 +7,7 @@ as a top level object.
 
 # Publisher::Post
 - title: (string, required)
+- body: (string)
 - tag: (Tag)
 
 # NonexistantService::Model

--- a/spec/support/contracts/service_test/publisher/publish.mson
+++ b/spec/support/contracts/service_test/publisher/publish.mson
@@ -12,11 +12,6 @@ properties right away):
 
 
 # Publisher::Post
-Although it is not necessary or recommended to use the publishing
-service's name as a prefix to the published object, we want to test
-that Lacerda just ignores the Publisher:: prefix in this case.
-
-## Properties
 - id: (number, required)
 - title: (string, required)
 - tag: (Tag)

--- a/spec/support/contracts/service_test/publisher/publish.mson
+++ b/spec/support/contracts/service_test/publisher/publish.mson
@@ -14,4 +14,6 @@ properties right away):
 # Publisher::Post
 - id: (number, required)
 - title: (string, required)
+- body: (string, required)
+- abstract: (string)
 - tag: (Tag)


### PR DESCRIPTION
Since [redsnow](https://github.com/apiaryio/redsnow) doesn't support the `nullable` type [yet](https://github.com/apiaryio/redsnow/issues/73), Lacerda makes all optional attributes `nullable` (fixes #16)
