### PR TITLE
Fix redsnow problems for lacerda 0.x

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,5 @@
 # 0.14.8
-- Fix rake to 11, to avoid problems building redsnow
+- Update redsnow 0.4.3 -> 0.4.4
 
 # 0.14.6
 - relax rake dependency

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,6 @@
+# 0.14.8
+- Fix rake to 11, to avoid problems building redsnow
+
 # 0.14.6
 - relax rake dependency
 - relax tins dependency

--- a/lacerda.gemspec
+++ b/lacerda.gemspec
@@ -20,11 +20,11 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.add_runtime_dependency "activesupport"
-  spec.add_runtime_dependency "rake", ["~> 11.0"]
+  spec.add_runtime_dependency "rake"
 
   spec.add_runtime_dependency "json-schema",   ["~> 2.6.2"]
 
-  spec.add_runtime_dependency "redsnow",       ["~> 0.4.3"]
+  spec.add_runtime_dependency "redsnow",       ["~> 0.4.4"]
   spec.add_runtime_dependency "colorize"
   spec.add_runtime_dependency "blumquist",     ["~> 0.5"]
 

--- a/lacerda.gemspec
+++ b/lacerda.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.add_runtime_dependency "activesupport"
-  spec.add_runtime_dependency "rake"
+  spec.add_runtime_dependency "rake", ["~> 11.0"]
 
   spec.add_runtime_dependency "json-schema",   ["~> 2.6.2"]
 

--- a/lib/lacerda/version.rb
+++ b/lib/lacerda/version.rb
@@ -1,3 +1,3 @@
 module Lacerda
-  VERSION = '0.14.7'
+  VERSION = '0.14.8'
 end


### PR DESCRIPTION
Master is in 1.0.0.beta, this is a fix created from tag v0.14.7, so we can build v0.14.8 without breaking changes.