### PR TITLE
dont support items with an array of types

### DIFF
--- a/lib/lacerda/compare/json_schema.rb
+++ b/lib/lacerda/compare/json_schema.rb
@@ -9,6 +9,7 @@ module Lacerda
         :ERR_MISSING_REQUIRED     => "The published object has an optional property that you marked as required in your specification.",
         :ERR_MISSING_TYPE_AND_REF_AND_ONE_OF => 'A property has to either have a "type", "oneOf" or "$ref" property.',
         :ERR_TYPE_MISMATCH        => "The published object has a property with a different type than the consumer's specification.",
+        :ERR_NOT_IMPLEMENTED      => "Not implemented.",
         :ERR_NOT_SUPPORTED        => 'I don\'t yet know what to do when the consumer\'s specification has a "$ref" defined and the publisher\'s specification has a "type".'
       }
 
@@ -168,15 +169,13 @@ module Lacerda
           end
         end
 
-        if consume['type'] == 'array'
-          publish['items'].each do |publish_item|
-            matched = consume['items'].any? do |consume_item|
-              schema_contains?(publish: publish_item, consume: consume_item)
-            end
-            return _e(:ERR_ARRAY_ITEM_MISMATCH, location, nil) unless matched
+        if consume['type'] == 'array' && publish['type'] == 'array'
+          if !consume['items'].is_a?(Hash) || !publish['items'].is_a?(Hash)
+            return _e(:ERR_NOT_IMPLEMENTED, location, "'items' can only be hash (schema)")
+           elsif !schema_contains?(publish: publish['items'], consume: consume['items'])
+            return _e(:ERR_ARRAY_ITEM_MISMATCH, location, nil)
           end
         end
-
         true
       end
 

--- a/lib/lacerda/compare/json_schema.rb
+++ b/lib/lacerda/compare/json_schema.rb
@@ -172,7 +172,7 @@ module Lacerda
         if consume['type'] == 'array' && publish['type'] == 'array'
           if !consume['items'].is_a?(Hash) || !publish['items'].is_a?(Hash)
             return _e(:ERR_NOT_IMPLEMENTED, location, "'items' can only be hash (schema)")
-           elsif !schema_contains?(publish: publish['items'], consume: consume['items'])
+          elsif !schema_contains?(publish: publish['items'], consume: consume['items'])
             return _e(:ERR_ARRAY_ITEM_MISMATCH, location, nil)
           end
         end

--- a/spec/lib/lacerda/compare/json_schema_spec.rb
+++ b/spec/lib/lacerda/compare/json_schema_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe JsonSchema do
             'id' => { 'type' => 'number', 'description' => 'The unique identifier for a post' },
             'title' => { 'type' => 'string', 'description' => 'Title of the product' },
             'author' => { 'type' => 'number', 'description' => 'External user id of author' },
-            'tags' => { 'type' => 'array', 'items' => [ { 'type' => 'string' } ] },
-            'multi_props'=> { 'type'=>'array', 'items'=> [ {
+            'tags' => { 'type' => 'array', 'items' => { 'type' => 'string' } },
+            'multi_props'=> { 'type'=>'array', 'items'=>  {
               'oneOf' => [
                 { 'type' => 'string' },
                 { '$ref' => '#/definitions/date' } ]
-            } ] }
+            }  }
           },
           'required' => [ 'id', 'title' ]
         }
@@ -57,12 +57,12 @@ RSpec.describe JsonSchema do
           'type' => 'object',
           'properties' => {
             'id' => { 'type' => 'number' },
-            'tags' => { 'type' => 'array', 'items' => [ { 'type' => 'string' } ] },
-            'multi_props'=> { 'type'=> 'array', 'items'=> [{
+            'tags' => { 'type' => 'array', 'items' => { 'type' => 'string' } },
+            'multi_props'=> { 'type'=> 'array', 'items'=> {
             'oneOf' => [
               { 'type' => 'string' },
               { '$ref' => '#/definitions/date' } ]
-          } ]},
+          } },
           },
           'required' => [ 'id', 'title' ]
         }
@@ -82,7 +82,7 @@ RSpec.describe JsonSchema do
           'type' => 'object',
           'BROKEN' => {
             'id' => { 'type' => 'number' },
-            'tags' => { 'type' => 'array', 'items' => [ { 'type' => 'string' } ] }
+            'tags' => { 'type' => 'array', 'items' => { 'type' => 'string' } }
           },
           'required' => [ 'id', 'title' ]
         }
@@ -329,7 +329,7 @@ RSpec.describe JsonSchema do
         end
 
         it 'misses a type in the oneOf' do
-          schema_b['definitions']['post']['properties']['multi_props']['items'][0]['oneOf'].delete({'type' => 'string'})
+          schema_b['definitions']['post']['properties']['multi_props']['items']['oneOf'].delete({'type' => 'string'})
           expect(comparator.contains?(schema_b)).to be false
           expect(comparator.errors.first[:error]).to be :ERR_MISSING_MULTI_PUBLISH_MULTI_CONSUME
         end
@@ -385,11 +385,11 @@ RSpec.describe JsonSchema do
         end
 
         it 'a different type for the items of a property of type array' do
-          schema_b['definitions']['post']['properties']['tags']['items'].first['type'] = 'number'
+          schema_b['definitions']['post']['properties']['tags']['items']['type'] = 'number'
 
           expect(comparator.contains?(schema_b)).to be false
-          expect(comparator.errors.length).to be 2
           expect(comparator.errors.map{|d| d[:error] }.sort).to eq [:ERR_ARRAY_ITEM_MISMATCH, :ERR_TYPE_MISMATCH]
+          expect(comparator.errors.length).to be 2
         end
       end
     end


### PR DESCRIPTION
The  way we convert mson to json is fine, but the way we compared them was a bit weird.  Json schema supports arrays  as types:

```
If "items" is a schema, validation succeeds if all elements in the array successfully validate against that schema.

If "items" is an array of schemas, validation succeeds if each element of the instance validates against the schema at the same position, if any.
```
I would prefere to ignore the second part as it is quite weird